### PR TITLE
Add minio credentials config

### DIFF
--- a/config/config.cfg
+++ b/config/config.cfg
@@ -16,3 +16,7 @@ PASSWORD = admin
 PROJECT = hipposeg
 VERIFY =  false
 SERVER = http://<remote server address>
+
+[minio]
+AWS_ACCESS_KEY_ID = minio
+AWS_SECRET_ACCESS_KEY = qwer1234!

--- a/config/local_config.cfg
+++ b/config/local_config.cfg
@@ -6,12 +6,12 @@ ARTIFACT_PATH = s3://mlflow
 [xnat]
 USER = admin
 PASSWORD = admin
-PROJECT = hipposeg1
+PROJECT = hipposeg
 VERIFY =  false
 SERVER = http://localhost/
 
 [project]
-NAME = hipposeg1
+NAME = hipposeg
 ;VOLUME_MOUNT = < data path>:/DATA
 
 [system]

--- a/config/local_config.cfg
+++ b/config/local_config.cfg
@@ -6,13 +6,17 @@ ARTIFACT_PATH = s3://mlflow
 [xnat]
 USER = admin
 PASSWORD = admin
-PROJECT = hipposeg
+PROJECT = hipposeg1
 VERIFY =  false
 SERVER = http://localhost/
 
 [project]
-NAME = hipposeg
+NAME = hipposeg1
 ;VOLUME_MOUNT = < data path>:/DATA
 
 [system]
 USE_GPU = false
+
+[minio]
+AWS_ACCESS_KEY_ID = minio
+AWS_SECRET_ACCESS_KEY = qwer1234!


### PR DESCRIPTION
This PR partially closes issue #7 by adding the MinIO credentials to the configuration files.

For a complete solution, please refer to the approach proposed in issue #176 of the MLOps repository, which finalizes the global pipeline configuration.